### PR TITLE
[BE #21] feat: 에러 응답 객체 구현

### DIFF
--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/ErrorCode.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/ErrorCode.java
@@ -1,0 +1,36 @@
+package kr.codesquad.airbnb11.common.error;
+
+public enum ErrorCode {
+  // Common
+  ENTITY_NOT_FOUND(404, "COM001", " Entity Not Found"),
+  INVALID_TYPE_VALUE(400, "COM002", "Wrong Type"),
+  INVALID_INPUT_VALUE(400, "COM003", "Wrong InputValue"),
+  METHOD_NOT_ALLOWED(405, "COM004", "Change Http Method"),
+  INTERNAL_SERVER_ERROR(500, "COM005", "백엔드 개발자라 죄송합니다..."),
+  // User
+  USER_NOT_FOUND(404, "U001", " 해당 사용자가 존재하지 않습니다."),
+  LOGIN_REQUIRED(401, "U002", " 로그인을 해주세요."),
+  ;
+
+  private final String code;
+  private final String message;
+  private final int status;
+
+  ErrorCode(final int status, final String code, final String message) {
+    this.status = status;
+    this.code = code;
+    this.message = message;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/ErrorResponse.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/ErrorResponse.java
@@ -1,0 +1,96 @@
+package kr.codesquad.airbnb11.common.error;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.validation.BindingResult;
+
+public class ErrorResponse {
+  private final int status;
+  private final String message;
+  private final String code;
+  private final List<FieldError> errors;
+
+  private ErrorResponse(final ErrorCode code) {
+    this.status = code.getStatus();
+    this.message = code.getMessage();
+    this.code = code.getCode();
+    this.errors = new ArrayList<>();
+  }
+
+  private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+    this.status = code.getStatus();
+    this.message = code.getMessage();
+    this.code = code.getCode();
+    this.errors = errors;
+  }
+
+  public static ErrorResponse of(final ErrorCode code) {
+    return new ErrorResponse(code);
+  }
+
+  public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+    return new ErrorResponse(code, FieldError.of(bindingResult));
+  }
+
+  public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
+    return new ErrorResponse(code, errors);
+  }
+
+  public int getStatus() {
+    return status;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public List<FieldError> getErrors() {
+    return errors;
+  }
+
+  public static class FieldError {
+
+    private String field;
+    private String value;
+    private String reason;
+
+    private FieldError(final String field, final Object value, final String reason) {
+      this.field = field;
+      this.value = value == null ? "" : value.toString();
+      this.reason = reason;
+    }
+
+    public static List<FieldError> of(final String field, final String value, final String reason) {
+      List<FieldError> fieldErrors = new ArrayList<>();
+      fieldErrors.add(new FieldError(field, value, reason));
+      return fieldErrors;
+    }
+
+    private static List<FieldError> of(final BindingResult bindingResult) {
+      final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+      return fieldErrors.stream()
+          .map(error -> new FieldError(
+              error.getField(),
+              error.getRejectedValue(),
+              error.getDefaultMessage()))
+          .collect(Collectors.toList());
+    }
+
+    public String getField() {
+      return field;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public String getReason() {
+      return reason;
+    }
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/GlobalRestExceptionHandler.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/GlobalRestExceptionHandler.java
@@ -1,0 +1,70 @@
+package kr.codesquad.airbnb11.common.error;
+
+import kr.codesquad.airbnb11.common.error.exception.BusinessException;
+import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalRestExceptionHandler {
+
+  private static final Logger log = org.slf4j.LoggerFactory
+      .getLogger(GlobalRestExceptionHandler.class);
+
+  /**
+   * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다.
+   * HttpMessageConverter 에서 등록한 HttpMessageConverter binding 못할경우 발생
+   * 주로 @RequestBody, @RequestPart 어노테이션에서 발생
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    log.error("handleMethodArgumentNotValidException", e);
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  /**
+   * 지원하지 않은 HTTP method 호출 할 경우 발생
+   */
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+    log.error("handleHttpRequestMethodNotSupportedException", e);
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+    return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+  }
+
+  /**
+   * 비즈니스 로직상의 에러
+   */
+  @ExceptionHandler(BusinessException.class)
+  protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+    log.error("handleEntityNotFoundException", e);
+    final ErrorCode errorCode = e.getErrorCode();
+    final ErrorResponse response = ErrorResponse.of(errorCode);
+    return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+  }
+
+  /**
+   * 범위 벗어나는 에러
+   */
+  @ExceptionHandler(IndexOutOfBoundsException.class)
+  protected ResponseEntity<ErrorResponse> handleIndexOutOfBoundException(IndexOutOfBoundsException e) {
+    log.error("handleIndexOutOfBoundException", e);
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.ENTITY_NOT_FOUND);
+    return new ResponseEntity<>(response, HttpStatus.valueOf(response.getStatus()));
+  }
+
+  /**
+   * 처리되지 않은 에러
+   */
+  @ExceptionHandler(Exception.class)
+  protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+    log.error("handleException", e);
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+    return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/exception/BusinessException.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/exception/BusinessException.java
@@ -1,0 +1,22 @@
+package kr.codesquad.airbnb11.common.error.exception;
+
+
+import kr.codesquad.airbnb11.common.error.ErrorCode;
+
+public class BusinessException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public BusinessException(String message, ErrorCode errorCode) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/exception/EntityNotFoundException.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/exception/EntityNotFoundException.java
@@ -1,0 +1,19 @@
+package kr.codesquad.airbnb11.common.error.exception;
+
+
+import kr.codesquad.airbnb11.common.error.ErrorCode;
+
+public class EntityNotFoundException extends BusinessException {
+
+  public EntityNotFoundException(String message) {
+    super(message, ErrorCode.ENTITY_NOT_FOUND);
+  }
+
+  public EntityNotFoundException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public EntityNotFoundException(String message, ErrorCode errorCode) {
+    super(message, errorCode);
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/exception/LoginRequiredException.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/exception/LoginRequiredException.java
@@ -1,0 +1,14 @@
+package kr.codesquad.airbnb11.common.error.exception;
+
+import kr.codesquad.airbnb11.common.error.ErrorCode;
+
+public class LoginRequiredException extends BusinessException {
+
+  public LoginRequiredException() {
+    super(ErrorCode.LOGIN_REQUIRED);
+  }
+
+  public LoginRequiredException(String message) {
+    super(message, ErrorCode.LOGIN_REQUIRED);
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/exception/UserNotFoundException.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package kr.codesquad.airbnb11.common.error.exception;
+
+import kr.codesquad.airbnb11.common.error.ErrorCode;
+
+public class UserNotFoundException extends EntityNotFoundException {
+
+  public UserNotFoundException() {
+    super(ErrorCode.USER_NOT_FOUND);
+  }
+
+  public UserNotFoundException(String message) {
+    super(message, ErrorCode.USER_NOT_FOUND);
+  }
+}


### PR DESCRIPTION
에러에 대해 일관적으로 응답해주는 에러 응답객체를 구현합니다.
ErrorCode 라는 Enum으로 Error 종류를 정의합니다.
예외 처리되지 않은 오류의 경우 500 Error응답을 리턴합니다.
BusinessException은 로직상에서 발생할 수 있는 모든 오류의 최상위 에러입니다.
EntityNotFoundException은 404 에러의 최상위 에러입니다.

Close #21 Issue.