### PR TITLE
[BE #29] feat : Api결과를 감쌀 result 객체 생성

### DIFF
--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/ApiError.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/ApiError.java
@@ -5,36 +5,36 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.validation.BindingResult;
 
-public class ErrorResponse {
+public class ApiError {
   private final int status;
   private final String message;
   private final String code;
   private final List<FieldError> errors;
 
-  private ErrorResponse(final ErrorCode code) {
+  private ApiError(final ErrorCode code) {
     this.status = code.getStatus();
     this.message = code.getMessage();
     this.code = code.getCode();
     this.errors = new ArrayList<>();
   }
 
-  private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+  private ApiError(final ErrorCode code, final List<FieldError> errors) {
     this.status = code.getStatus();
     this.message = code.getMessage();
     this.code = code.getCode();
     this.errors = errors;
   }
 
-  public static ErrorResponse of(final ErrorCode code) {
-    return new ErrorResponse(code);
+  public static ApiError of(final ErrorCode code) {
+    return new ApiError(code);
   }
 
-  public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
-    return new ErrorResponse(code, FieldError.of(bindingResult));
+  public static ApiError of(final ErrorCode code, final BindingResult bindingResult) {
+    return new ApiError(code, FieldError.of(bindingResult));
   }
 
-  public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
-    return new ErrorResponse(code, errors);
+  public static ApiError of(final ErrorCode code, final List<FieldError> errors) {
+    return new ApiError(code, errors);
   }
 
   public int getStatus() {

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/ApiResult.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/ApiResult.java
@@ -13,9 +13,15 @@ public class ApiResult<T> {
 
   private final ApiError error;
 
-  public ApiResult(boolean success, T response, ApiError error) {
+  private ApiResult(boolean success, T response, ApiError error) {
     this.success = success;
     this.response = response;
+    this.error = error;
+  }
+
+  private ApiResult(boolean success, ApiError error) {
+    this.success = success;
+    this.response = null;
     this.error = error;
   }
 
@@ -23,16 +29,17 @@ public class ApiResult<T> {
     return new ApiResult<>(true, response, null);
   }
 
+
   public static ApiResult ERROR(ErrorCode code) {
-    return new ApiResult<>(false, null, ApiError.of(code));
+    return new ApiResult<>(false, ApiError.of(code));
   }
 
   public static ApiResult ERROR(ErrorCode code, BindingResult bindingResult) {
-    return new ApiResult<>(false, null, ApiError.of(code, bindingResult));
+    return new ApiResult<>(false, ApiError.of(code, bindingResult));
   }
 
   public static ApiResult ERROR(ErrorCode code, List<FieldError> errors) {
-    return new ApiResult<>(false, null, ApiError.of(code, errors));
+    return new ApiResult<>(false, ApiError.of(code, errors));
   }
 
   public boolean isSuccess() {

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/ApiResult.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/ApiResult.java
@@ -8,9 +8,7 @@ import org.springframework.validation.BindingResult;
 public class ApiResult<T> {
 
   private final boolean success;
-
   private final T response;
-
   private final ApiError error;
 
   private ApiResult(boolean success, T response, ApiError error) {
@@ -28,7 +26,6 @@ public class ApiResult<T> {
   public static <T> ApiResult<T> OK(T response) {
     return new ApiResult<>(true, response, null);
   }
-
 
   public static ApiResult ERROR(ErrorCode code) {
     return new ApiResult<>(false, ApiError.of(code));

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/ApiResult.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/ApiResult.java
@@ -1,0 +1,58 @@
+package kr.codesquad.airbnb11.common.error;
+
+import java.util.List;
+import kr.codesquad.airbnb11.common.error.ErrorResponse.FieldError;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.springframework.validation.BindingResult;
+
+public class ApiResult<T> {
+
+  private final boolean success;
+
+  private final T response;
+
+  private final ErrorResponse error;
+
+  public ApiResult(boolean success, T response, ErrorResponse error) {
+    this.success = success;
+    this.response = response;
+    this.error = error;
+  }
+
+  public static <T> ApiResult<T> OK(T response) {
+    return new ApiResult<>(true, response, null);
+  }
+
+  public static ApiResult ERROR(ErrorCode code) {
+    return new ApiResult<>(false, null, ErrorResponse.of(code));
+  }
+
+  public static ApiResult ERROR(ErrorCode code, BindingResult bindingResult) {
+    return new ApiResult<>(false, null, ErrorResponse.of(code, bindingResult));
+  }
+
+  public static ApiResult ERROR(ErrorCode code, List<FieldError> errors) {
+    return new ApiResult<>(false, null, ErrorResponse.of(code, errors));
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public T getResponse() {
+    return response;
+  }
+
+  public ErrorResponse getError() {
+    return error;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("success", success)
+        .append("response", response)
+        .append("error", error)
+        .toString();
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/ApiResult.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/ApiResult.java
@@ -1,7 +1,7 @@
 package kr.codesquad.airbnb11.common.error;
 
 import java.util.List;
-import kr.codesquad.airbnb11.common.error.ErrorResponse.FieldError;
+import kr.codesquad.airbnb11.common.error.ApiError.FieldError;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.springframework.validation.BindingResult;
 
@@ -11,9 +11,9 @@ public class ApiResult<T> {
 
   private final T response;
 
-  private final ErrorResponse error;
+  private final ApiError error;
 
-  public ApiResult(boolean success, T response, ErrorResponse error) {
+  public ApiResult(boolean success, T response, ApiError error) {
     this.success = success;
     this.response = response;
     this.error = error;
@@ -24,15 +24,15 @@ public class ApiResult<T> {
   }
 
   public static ApiResult ERROR(ErrorCode code) {
-    return new ApiResult<>(false, null, ErrorResponse.of(code));
+    return new ApiResult<>(false, null, ApiError.of(code));
   }
 
   public static ApiResult ERROR(ErrorCode code, BindingResult bindingResult) {
-    return new ApiResult<>(false, null, ErrorResponse.of(code, bindingResult));
+    return new ApiResult<>(false, null, ApiError.of(code, bindingResult));
   }
 
   public static ApiResult ERROR(ErrorCode code, List<FieldError> errors) {
-    return new ApiResult<>(false, null, ErrorResponse.of(code, errors));
+    return new ApiResult<>(false, null, ApiError.of(code, errors));
   }
 
   public boolean isSuccess() {
@@ -43,7 +43,7 @@ public class ApiResult<T> {
     return response;
   }
 
-  public ErrorResponse getError() {
+  public ApiError getError() {
     return error;
   }
 

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/error/GlobalRestExceptionHandler.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/error/GlobalRestExceptionHandler.java
@@ -21,9 +21,9 @@ public class GlobalRestExceptionHandler {
    * 주로 @RequestBody, @RequestPart 어노테이션에서 발생
    */
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+  protected ResponseEntity<ApiError> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
     log.error("handleMethodArgumentNotValidException", e);
-    final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+    final ApiError response = ApiError.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
     return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }
 
@@ -31,9 +31,9 @@ public class GlobalRestExceptionHandler {
    * 지원하지 않은 HTTP method 호출 할 경우 발생
    */
   @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-  protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+  protected ResponseEntity<ApiError> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
     log.error("handleHttpRequestMethodNotSupportedException", e);
-    final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+    final ApiError response = ApiError.of(ErrorCode.METHOD_NOT_ALLOWED);
     return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
   }
 
@@ -41,10 +41,10 @@ public class GlobalRestExceptionHandler {
    * 비즈니스 로직상의 에러
    */
   @ExceptionHandler(BusinessException.class)
-  protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+  protected ResponseEntity<ApiError> handleBusinessException(final BusinessException e) {
     log.error("handleEntityNotFoundException", e);
     final ErrorCode errorCode = e.getErrorCode();
-    final ErrorResponse response = ErrorResponse.of(errorCode);
+    final ApiError response = ApiError.of(errorCode);
     return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
   }
 
@@ -52,9 +52,9 @@ public class GlobalRestExceptionHandler {
    * 범위 벗어나는 에러
    */
   @ExceptionHandler(IndexOutOfBoundsException.class)
-  protected ResponseEntity<ErrorResponse> handleIndexOutOfBoundException(IndexOutOfBoundsException e) {
+  protected ResponseEntity<ApiError> handleIndexOutOfBoundException(IndexOutOfBoundsException e) {
     log.error("handleIndexOutOfBoundException", e);
-    final ErrorResponse response = ErrorResponse.of(ErrorCode.ENTITY_NOT_FOUND);
+    final ApiError response = ApiError.of(ErrorCode.ENTITY_NOT_FOUND);
     return new ResponseEntity<>(response, HttpStatus.valueOf(response.getStatus()));
   }
 
@@ -62,9 +62,9 @@ public class GlobalRestExceptionHandler {
    * 처리되지 않은 에러
    */
   @ExceptionHandler(Exception.class)
-  protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+  protected ResponseEntity<ApiError> handleException(Exception e) {
     log.error("handleException", e);
-    final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+    final ApiError response = ApiError.of(ErrorCode.INTERNAL_SERVER_ERROR);
     return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }


### PR DESCRIPTION
error response 기반 ApiResult 생성

@ksundong 질문하고 싶은 것이 있습니다
> BindingResult,  List<FieldError> errors의 역할
- 에러를 3가지 방법으로 나눠서 다루시고 있는 것 같은데 `BindingResult`과 `List<FieldError>` 어떨때 사용하는 건지 궁금합니다!
- 그리고 ErrorResponse를 통일성을 위해서 ApiError 괜찮을까요?
