### PR TITLE
[BE] login oauth

### DIFF
--- a/BE/src/main/java/kr/codesquad/airbnb11/common/config/WebConfig.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/config/WebConfig.java
@@ -4,6 +4,7 @@ import kr.codesquad.airbnb11.common.security.GithubKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -18,6 +19,11 @@ public class WebConfig implements WebMvcConfigurer {
   @Bean
   public GithubKey githubKey() {
     return new GithubKey(clientId, clientSecret);
+  }
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
   }
 
   @Override

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/config/WebConfig.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/config/WebConfig.java
@@ -1,11 +1,24 @@
 package kr.codesquad.airbnb11.common.config;
 
+import kr.codesquad.airbnb11.common.security.GithubKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+  @Value("${github.client-id}")
+  String clientId;
+  @Value("${github.client-secret}")
+  String clientSecret;
+
+  @Bean
+  public GithubKey githubKey() {
+    return new GithubKey(clientId, clientSecret);
+  }
 
   @Override
   public void addCorsMappings(CorsRegistry registry) {

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/security/GithubKey.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/security/GithubKey.java
@@ -1,0 +1,31 @@
+package kr.codesquad.airbnb11.common.security;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class GithubKey {
+
+  private final String clientId;
+  private final String clientSecret;
+
+  public GithubKey(String clientId, String clientSecret) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("clientId", clientId)
+        .append("clientSecret", clientSecret)
+        .toString();
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/security/GithubPayload.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/security/GithubPayload.java
@@ -1,23 +1,27 @@
 package kr.codesquad.airbnb11.common.security;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class GithubPayload {
 
   @JsonProperty("client_id")
-  private final String clientId = System.getenv("GITHUB_CLIENT_ID");
+  private final String clientId;
 
   @JsonProperty("client_secret")
-  private final String clientSecret = System.getenv("GITHUB_CLIENT_SECRET");
+  private final String clientSecret;
 
   private final String code;
 
-  private GithubPayload(String code) {
+  private GithubPayload(String clientId, String clientSecret, String code) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
     this.code = code;
   }
 
-  public static GithubPayload valueOf(String code) {
-    return new GithubPayload(code);
+  public static GithubPayload of(String clientId, String clientSecret, String code) {
+    return new GithubPayload(clientId, clientSecret, code);
   }
 
   public String getClientId() {
@@ -30,5 +34,14 @@ public class GithubPayload {
 
   public String getCode() {
     return code;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("clientId", clientId)
+        .append("clientSecret", clientSecret)
+        .append("code", code)
+        .toString();
   }
 }

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/security/GithubPayload.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/security/GithubPayload.java
@@ -1,0 +1,34 @@
+package kr.codesquad.airbnb11.common.security;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GithubPayload {
+
+  @JsonProperty("client_id")
+  private final String clientId = System.getenv("GITHUB_CLIENT_ID");
+
+  @JsonProperty("client_secret")
+  private final String clientSecret = System.getenv("GITHUB_CLIENT_SECRET");
+
+  private final String code;
+
+  private GithubPayload(String code) {
+    this.code = code;
+  }
+
+  public static GithubPayload valueOf(String code) {
+    return new GithubPayload(code);
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  public String getCode() {
+    return code;
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/security/GithubPayload.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/security/GithubPayload.java
@@ -20,8 +20,8 @@ public class GithubPayload {
     this.code = code;
   }
 
-  public static GithubPayload of(String clientId, String clientSecret, String code) {
-    return new GithubPayload(clientId, clientSecret, code);
+  public static GithubPayload of(GithubKey githubKey, String code) {
+    return new GithubPayload(githubKey.getClientId(), githubKey.getClientSecret(), code);
   }
 
   public String getClientId() {

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/security/GithubToken.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/security/GithubToken.java
@@ -1,0 +1,39 @@
+package kr.codesquad.airbnb11.common.security;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GithubToken {
+
+  @JsonProperty("access_token")
+  private String accessToken;
+
+  @JsonProperty("token_type")
+  private String tokenType;
+
+  @JsonProperty("scope")
+  private String scope;
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
+  }
+
+  public String getTokenType() {
+    return tokenType;
+  }
+
+  public void setTokenType(String tokenType) {
+    this.tokenType = tokenType;
+  }
+
+  public String getScope() {
+    return scope;
+  }
+
+  public void setScope(String scope) {
+    this.scope = scope;
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/security/GithubUser.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/security/GithubUser.java
@@ -1,0 +1,41 @@
+package kr.codesquad.airbnb11.common.security;
+
+public class GithubUser {
+
+  private String login;
+  private String name;
+  private String email;
+  private String token;
+
+  public String getLogin() {
+    return login;
+  }
+
+  public void setLogin(String login) {
+    this.login = login;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public void setToken(String token) {
+    this.token = token;
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/common/security/JwtUtil.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/common/security/JwtUtil.java
@@ -1,0 +1,97 @@
+package kr.codesquad.airbnb11.common.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import kr.codesquad.airbnb11.common.error.exception.LoginRequiredException;
+import kr.codesquad.airbnb11.domain.user.UserDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+  private static final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+  private static final String USER_JWT_KEY = "user";
+  private static final Logger log = LoggerFactory.getLogger(JwtUtil.class);
+
+  public String createJws(String jwtKey, Object data) {
+    Map<String, Object> headers = new HashMap<>();
+    headers.put("typ", "JWT");
+    headers.put("alg", "HS256");
+
+    Map<String, Object> payloads = new HashMap<>();
+    payloads.put(jwtKey, data);
+
+    return Jwts.builder()
+        .setHeader(headers)
+        .setClaims(payloads)
+        .signWith(key)
+        .compact();
+  }
+
+  public String createJws(Map<String, Object> payloads) {
+    Map<String, Object> headers = new HashMap<>();
+    headers.put("typ", "JWT");
+    headers.put("alg", "HS256");
+
+    return Jwts.builder()
+        .setHeader(headers)
+        .setClaims(payloads)
+        .signWith(key)
+        .compact();
+  }
+
+  public String createUserJws(UserDTO data) {
+    Map<String, Object> headers = new HashMap<>();
+    headers.put("typ", "JWT");
+    headers.put("alg", "HS256");
+
+    Map<String, UserDTO> payloads = new HashMap<>();
+    payloads.put(USER_JWT_KEY, data);
+
+    return Jwts.builder()
+        .setHeader(headers)
+        .setClaims(payloads)
+        .signWith(key)
+        .compact();
+  }
+
+  public Map<String, Object> getDataFromJws(String jwtKey, String jws) {
+    Jws<Claims> claims;
+    try {
+      claims = Jwts.parserBuilder()
+          .setSigningKey(key)
+          .build()
+          .parseClaimsJws(jws);
+      return (LinkedHashMap<String, Object>) claims.getBody().get(jwtKey);
+    } catch (JwtException ex) {
+      log.error("인증되지 않은 jwt token입니다. jws: {}", jws);
+      // Custom Exception Unauthorized Exception
+      throw new LoginRequiredException("인증되지 않은 jwt token입니다.");
+    }
+  }
+
+  public UserDTO getUserFromJws(String jws) {
+    Jws<Claims> claims;
+    try {
+      claims = Jwts.parserBuilder()
+          .setSigningKey(key)
+          .build()
+          .parseClaimsJws(jws);
+      return UserDTO.of((LinkedHashMap<String, String>) claims.getBody().get(USER_JWT_KEY));
+    } catch (JwtException ex) {
+      log.error("인증되지 않은 jwt token입니다. jws: {}", jws);
+      // Custom Exception Unauthorized Exception
+      throw new LoginRequiredException("인증되지 않은 jwt token입니다.");
+    }
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/controller/LoginController.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/controller/LoginController.java
@@ -1,0 +1,81 @@
+package kr.codesquad.airbnb11.controller;
+
+import java.net.URI;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import kr.codesquad.airbnb11.common.security.JwtUtil;
+import kr.codesquad.airbnb11.domain.user.User;
+import kr.codesquad.airbnb11.domain.user.UserDTO;
+import kr.codesquad.airbnb11.service.OAuthService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RestController
+@RequestMapping("/login")
+public class LoginController {
+
+  private static final Logger log = LoggerFactory.getLogger(LoginController.class);
+  private final OAuthService authService;
+  private final JwtUtil jwtUtil;
+
+  public LoginController(OAuthService authService, JwtUtil jwtUtil) {
+    this.authService = authService;
+    this.jwtUtil = jwtUtil;
+  }
+
+  @GetMapping
+  public ResponseEntity<String> loginWithGithub(
+      @CookieValue(value = "jwt", required = false) String jwt) {
+    if (jwt != null) {
+      log.debug("jwt 토큰 값: {}", jwt);
+      log.debug("jwt에 저장된 값: {}", jwtUtil.getUserFromJws(jwt));
+      return ResponseEntity.ok("ok");
+    }
+
+    HttpHeaders headers = new HttpHeaders();
+    URI uri = UriComponentsBuilder.fromUriString("https://github.com/login/oauth/authorize")
+        .queryParam("client_id", System.getenv("GITHUB_CLIENT_ID"))
+        .queryParam("scope", "user")
+        .build()
+        .toUri();
+    headers.setLocation(uri);
+    return new ResponseEntity<>("redirect", headers, HttpStatus.SEE_OTHER);
+  }
+
+  @GetMapping("/oauth")
+  public ResponseEntity<String> oauthAuthentication(@RequestParam("code") String code,
+      HttpServletResponse response) {
+    String accessToken = authService.getCodeFromGithubToken(code).getAccessToken();
+    log.debug("AccessToken: {}", accessToken);
+
+    User saved = authService.insertUser(accessToken);
+
+    UserDTO user = UserDTO.builder()
+        .email(saved.getEmail())
+        .nickname(saved.getNickname())
+        .build();
+
+    log.debug("JWT에 담길 User 정보: {}", user);
+
+    String jws = jwtUtil.createUserJws(user);
+    log.debug("jws: {}", jws);
+
+    Cookie cookie = new Cookie("jwt", jws);
+    cookie.setMaxAge(7 * 24 * 60 * 60); // expires in 7 days
+    cookie.setPath("/");
+
+    response.addCookie(cookie);
+    response.setHeader("Location", "http://localhost:8080");
+    return new ResponseEntity<>("redirect", HttpStatus.FOUND);
+  }
+
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/controller/LoginController.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/controller/LoginController.java
@@ -3,6 +3,7 @@ package kr.codesquad.airbnb11.controller;
 import java.net.URI;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
+import kr.codesquad.airbnb11.common.security.GithubKey;
 import kr.codesquad.airbnb11.common.security.JwtUtil;
 import kr.codesquad.airbnb11.domain.user.User;
 import kr.codesquad.airbnb11.domain.user.UserDTO;
@@ -26,10 +27,13 @@ public class LoginController {
   private static final Logger log = LoggerFactory.getLogger(LoginController.class);
   private final OAuthService authService;
   private final JwtUtil jwtUtil;
+  private final GithubKey githubKey;
 
-  public LoginController(OAuthService authService, JwtUtil jwtUtil) {
+  public LoginController(OAuthService authService,
+      JwtUtil jwtUtil, GithubKey githubKey) {
     this.authService = authService;
     this.jwtUtil = jwtUtil;
+    this.githubKey = githubKey;
   }
 
   @GetMapping
@@ -43,7 +47,7 @@ public class LoginController {
 
     HttpHeaders headers = new HttpHeaders();
     URI uri = UriComponentsBuilder.fromUriString("https://github.com/login/oauth/authorize")
-        .queryParam("client_id", System.getenv("GITHUB_CLIENT_ID"))
+        .queryParam("client_id", githubKey.getClientId())
         .queryParam("scope", "user")
         .build()
         .toUri();
@@ -54,7 +58,7 @@ public class LoginController {
   @GetMapping("/oauth")
   public ResponseEntity<String> oauthAuthentication(@RequestParam("code") String code,
       HttpServletResponse response) {
-    String accessToken = authService.getCodeFromGithubToken(code).getAccessToken();
+    String accessToken = authService.getTokenFromCode(code).getAccessToken();
     log.debug("AccessToken: {}", accessToken);
 
     User saved = authService.insertUser(accessToken);

--- a/BE/src/main/java/kr/codesquad/airbnb11/controller/LoginController.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/controller/LoginController.java
@@ -1,12 +1,9 @@
 package kr.codesquad.airbnb11.controller;
 
-import java.net.URI;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
-import kr.codesquad.airbnb11.common.security.GithubKey;
 import kr.codesquad.airbnb11.common.security.JwtUtil;
 import kr.codesquad.airbnb11.domain.user.User;
 import kr.codesquad.airbnb11.domain.user.UserDTO;
+import kr.codesquad.airbnb11.service.LoginService;
 import kr.codesquad.airbnb11.service.OAuthService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +15,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 @RequestMapping("/login")
@@ -26,14 +22,13 @@ public class LoginController {
 
   private static final Logger log = LoggerFactory.getLogger(LoginController.class);
   private final OAuthService authService;
+  private final LoginService loginService;
   private final JwtUtil jwtUtil;
-  private final GithubKey githubKey;
 
-  public LoginController(OAuthService authService,
-      JwtUtil jwtUtil, GithubKey githubKey) {
+  public LoginController(OAuthService authService, LoginService loginService, JwtUtil jwtUtil) {
     this.authService = authService;
+    this.loginService = loginService;
     this.jwtUtil = jwtUtil;
-    this.githubKey = githubKey;
   }
 
   @GetMapping
@@ -42,44 +37,26 @@ public class LoginController {
     if (jwt != null) {
       log.debug("jwt 토큰 값: {}", jwt);
       log.debug("jwt에 저장된 값: {}", jwtUtil.getUserFromJws(jwt));
-      return ResponseEntity.ok("ok");
+      return ResponseEntity.ok(jwtUtil.getUserFromJws(jwt).toString());
     }
-
-    HttpHeaders headers = new HttpHeaders();
-    URI uri = UriComponentsBuilder.fromUriString("https://github.com/login/oauth/authorize")
-        .queryParam("client_id", githubKey.getClientId())
-        .queryParam("scope", "user")
-        .build()
-        .toUri();
-    headers.setLocation(uri);
+    HttpHeaders headers = loginService.redirectToGithub();
     return new ResponseEntity<>("redirect", headers, HttpStatus.SEE_OTHER);
   }
 
   @GetMapping("/oauth")
-  public ResponseEntity<String> oauthAuthentication(@RequestParam("code") String code,
-      HttpServletResponse response) {
+  public ResponseEntity<String> oauthAuthentication(@RequestParam("code") String code) {
     String accessToken = authService.getTokenFromCode(code).getAccessToken();
     log.debug("AccessToken: {}", accessToken);
 
-    User saved = authService.insertUser(accessToken);
-
-    UserDTO user = UserDTO.builder()
-        .email(saved.getEmail())
-        .nickname(saved.getNickname())
-        .build();
+    User saved = loginService.insertUser(accessToken);
+    UserDTO user = loginService.createUserDTO(saved.getNickname(), saved.getEmail());
 
     log.debug("JWT에 담길 User 정보: {}", user);
 
     String jws = jwtUtil.createUserJws(user);
     log.debug("jws: {}", jws);
 
-    Cookie cookie = new Cookie("jwt", jws);
-    cookie.setMaxAge(7 * 24 * 60 * 60); // expires in 7 days
-    cookie.setPath("/");
-
-    response.addCookie(cookie);
-    response.setHeader("Location", "http://localhost:8080");
-    return new ResponseEntity<>("redirect", HttpStatus.FOUND);
+    HttpHeaders headers = loginService.redirectWithCookie(jws);
+    return new ResponseEntity<>("redirect", headers, HttpStatus.FOUND);
   }
-
 }

--- a/BE/src/main/java/kr/codesquad/airbnb11/domain/user/User.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/domain/user/User.java
@@ -1,0 +1,141 @@
+package kr.codesquad.airbnb11.domain.user;
+
+import kr.codesquad.airbnb11.common.security.GithubUser;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+
+public class User {
+
+  @Id
+  private final Integer id;
+  private final Boolean isAdmin;
+  private final String email;
+  private final String nickname;
+  private final String githubToken;
+  private Boolean isHost;
+  private Boolean isSuperHost;
+
+  @PersistenceConstructor
+  private User(Integer id, Boolean isHost, Boolean isSuperHost, Boolean isAdmin,
+      String email, String nickname, String githubToken) {
+    this.id = id;
+    this.isHost = isHost;
+    this.isSuperHost = isSuperHost;
+    this.isAdmin = isAdmin;
+    this.email = email;
+    this.nickname = nickname;
+    this.githubToken = githubToken;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static Builder builder(GithubUser user) {
+    return new Builder(user);
+  }
+
+  User withId(Integer id) {
+    return new User(id, this.isHost, this.isSuperHost, this.isAdmin, this.email, this.nickname,
+        this.githubToken);
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public Boolean getHost() {
+    return isHost;
+  }
+
+  public Boolean getSuperHost() {
+    return isSuperHost;
+  }
+
+  public Boolean getAdmin() {
+    return isAdmin;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getNickname() {
+    return nickname;
+  }
+
+  public String getGithubToken() {
+    return githubToken;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("id", id)
+        .append("isHost", isHost)
+        .append("isSuperHost", isSuperHost)
+        .append("isAdmin", isAdmin)
+        .append("email", email)
+        .append("nickname", nickname)
+        .append("githubToken", githubToken)
+        .toString();
+  }
+
+  public static final class Builder {
+
+    private Boolean isHost;
+    private Boolean isSuperHost;
+    private Boolean isAdmin;
+    private String email;
+    private String nickname;
+    private String githubToken;
+
+    private Builder() {
+    }
+
+    private Builder(GithubUser githubUser) {
+      this.isHost = false;
+      this.isSuperHost = false;
+      this.isAdmin = false;
+      this.email = githubUser.getEmail();
+      this.nickname = githubUser.getName();
+      this.githubToken = githubUser.getToken();
+    }
+
+    public Builder isHost(Boolean isHost) {
+      this.isHost = isHost;
+      return this;
+    }
+
+    public Builder isSuperHost(Boolean isSuperHost) {
+      this.isSuperHost = isSuperHost;
+      return this;
+    }
+
+    public Builder isAdmin(Boolean isAdmin) {
+      this.isAdmin = isAdmin;
+      return this;
+    }
+
+    public Builder email(String email) {
+      this.email = email;
+      return this;
+    }
+
+    public Builder nickname(String nickname) {
+      this.nickname = nickname;
+      return this;
+    }
+
+    public Builder githubToken(String githubToken) {
+      this.githubToken = githubToken;
+      return this;
+    }
+
+    public User build() {
+      return new User(null, isHost, isSuperHost, isAdmin, email, nickname, githubToken);
+    }
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/domain/user/User.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/domain/user/User.java
@@ -37,11 +37,6 @@ public class User {
     return new Builder(user);
   }
 
-  User withId(Integer id) {
-    return new User(id, this.isHost, this.isSuperHost, this.isAdmin, this.email, this.nickname,
-        this.githubToken);
-  }
-
   public Integer getId() {
     return id;
   }

--- a/BE/src/main/java/kr/codesquad/airbnb11/domain/user/UserDTO.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/domain/user/UserDTO.java
@@ -1,0 +1,68 @@
+package kr.codesquad.airbnb11.domain.user;
+
+import java.util.Map;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class UserDTO {
+
+  private final String nickname;
+  private final String email;
+
+  private UserDTO(String nickname, String email) {
+    this.nickname = nickname;
+    this.email = email;
+  }
+
+  private UserDTO(Map<String, String> userMap) {
+    this.nickname = userMap.get("nickname");
+    this.email = userMap.get("email");
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static UserDTO of(Map<String, String> userMap) {
+    return new UserDTO(userMap);
+  }
+
+  public String getNickname() {
+    return nickname;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+        .append("nickname", nickname)
+        .append("email", email)
+        .toString();
+  }
+
+  public static final class Builder {
+
+    private String nickname;
+    private String email;
+
+    private Builder() {
+    }
+
+    public Builder nickname(String nickname) {
+      this.nickname = nickname;
+      return this;
+    }
+
+    public Builder email(String email) {
+      this.email = email;
+      return this;
+    }
+
+    public UserDTO build() {
+      return new UserDTO(nickname, email);
+    }
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/domain/user/UserDTO.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/domain/user/UserDTO.java
@@ -19,8 +19,8 @@ public class UserDTO {
     this.email = userMap.get("email");
   }
 
-  public static Builder builder() {
-    return new Builder();
+  public static UserDTO of(String nickname, String email) {
+    return new UserDTO(nickname, email);
   }
 
   public static UserDTO of(Map<String, String> userMap) {
@@ -37,32 +37,9 @@ public class UserDTO {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+    return new ToStringBuilder(this, ToStringStyle.JSON_STYLE)
         .append("nickname", nickname)
         .append("email", email)
         .toString();
-  }
-
-  public static final class Builder {
-
-    private String nickname;
-    private String email;
-
-    private Builder() {
-    }
-
-    public Builder nickname(String nickname) {
-      this.nickname = nickname;
-      return this;
-    }
-
-    public Builder email(String email) {
-      this.email = email;
-      return this;
-    }
-
-    public UserDTO build() {
-      return new UserDTO(nickname, email);
-    }
   }
 }

--- a/BE/src/main/java/kr/codesquad/airbnb11/domain/user/UserDTO.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/domain/user/UserDTO.java
@@ -37,7 +37,7 @@ public class UserDTO {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.JSON_STYLE)
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
         .append("nickname", nickname)
         .append("email", email)
         .toString();

--- a/BE/src/main/java/kr/codesquad/airbnb11/domain/user/UserRepository.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/domain/user/UserRepository.java
@@ -1,0 +1,10 @@
+package kr.codesquad.airbnb11.domain.user;
+
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+
+public interface UserRepository extends CrudRepository<User, Integer> {
+
+  Optional<User> findByEmail(String email);
+
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/domain/user/UserRepository.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/domain/user/UserRepository.java
@@ -1,10 +1,9 @@
 package kr.codesquad.airbnb11.domain.user;
 
 import java.util.Optional;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
-public interface UserRepository extends CrudRepository<User, Integer> {
+public interface UserRepository extends PagingAndSortingRepository<User, Integer> {
 
   Optional<User> findByEmail(String email);
-
 }

--- a/BE/src/main/java/kr/codesquad/airbnb11/service/JwtService.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/service/JwtService.java
@@ -1,4 +1,4 @@
-package kr.codesquad.airbnb11.common.security;
+package kr.codesquad.airbnb11.service;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -14,14 +14,14 @@ import kr.codesquad.airbnb11.common.error.exception.LoginRequiredException;
 import kr.codesquad.airbnb11.domain.user.UserDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
-public class JwtUtil {
+@Service
+public class JwtService {
 
   private static final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
   private static final String USER_JWT_KEY = "user";
-  private static final Logger log = LoggerFactory.getLogger(JwtUtil.class);
+  private static final Logger log = LoggerFactory.getLogger(JwtService.class);
 
   public String createJws(String jwtKey, Object data) {
     Map<String, Object> headers = new HashMap<>();
@@ -66,13 +66,12 @@ public class JwtUtil {
   }
 
   public Map<String, Object> getDataFromJws(String jwtKey, String jws) {
-    Jws<Claims> claims;
     try {
-      claims = Jwts.parserBuilder()
+      Jws<Claims> claims = Jwts.parserBuilder()
           .setSigningKey(key)
           .build()
           .parseClaimsJws(jws);
-      return (LinkedHashMap<String, Object>) claims.getBody().get(jwtKey);
+      return (LinkedHashMap) claims.getBody().get(jwtKey);
     } catch (JwtException ex) {
       log.error("인증되지 않은 jwt token입니다. jws: {}", jws);
       // Custom Exception Unauthorized Exception
@@ -81,13 +80,12 @@ public class JwtUtil {
   }
 
   public UserDTO getUserFromJws(String jws) {
-    Jws<Claims> claims;
     try {
-      claims = Jwts.parserBuilder()
+      Jws<Claims> claims = Jwts.parserBuilder()
           .setSigningKey(key)
           .build()
           .parseClaimsJws(jws);
-      return UserDTO.of((LinkedHashMap<String, String>) claims.getBody().get(USER_JWT_KEY));
+      return UserDTO.of((LinkedHashMap) claims.getBody().get(USER_JWT_KEY));
     } catch (JwtException ex) {
       log.error("인증되지 않은 jwt token입니다. jws: {}", jws);
       // Custom Exception Unauthorized Exception

--- a/BE/src/main/java/kr/codesquad/airbnb11/service/LoginService.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/service/LoginService.java
@@ -1,0 +1,74 @@
+package kr.codesquad.airbnb11.service;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import kr.codesquad.airbnb11.common.error.exception.UserNotFoundException;
+import kr.codesquad.airbnb11.common.security.GithubKey;
+import kr.codesquad.airbnb11.domain.user.User;
+import kr.codesquad.airbnb11.domain.user.UserDTO;
+import kr.codesquad.airbnb11.domain.user.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class LoginService {
+
+  private static final Logger log = LoggerFactory.getLogger(LoginService.class);
+  private final GithubKey githubKey;
+  private final OAuthService authService;
+  private final UserRepository userRepository;
+
+  public LoginService(GithubKey githubKey, OAuthService authService,
+      UserRepository userRepository) {
+    this.githubKey = githubKey;
+    this.authService = authService;
+    this.userRepository = userRepository;
+  }
+
+  public HttpHeaders redirectToGithub() {
+    HttpHeaders headers = new HttpHeaders();
+    URI uri = UriComponentsBuilder.fromUriString("https://github.com/login/oauth/authorize")
+        .queryParam("client_id", githubKey.getClientId())
+        .queryParam("scope", "user")
+        .build()
+        .toUri();
+    headers.setLocation(uri);
+    return headers;
+  }
+
+  public HttpHeaders redirectWithCookie(String jwt) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+
+    int maxAge = 7 * 24 * 60 * 60;
+
+    headers.add("Authorization", "Bearer " + jwt);
+    headers.add("Set-Cookie", "jwt=" + jwt + "; Path=/" + "; Max-Age=" + maxAge + ";");
+    headers.setLocation(URI.create("http://localhost:8080/login"));
+    return headers;
+  }
+
+
+  public User insertUser(String token) {
+    User user = authService.getUserInfoToToken(token);
+    log.debug("DB 저장 전 User 정보: {}", user);
+    User savedUser;
+
+    try {
+      savedUser = userRepository.findByEmail(user.getEmail()).orElseThrow(UserNotFoundException::new);
+    } catch (UserNotFoundException e) {
+      savedUser = userRepository.save(user);
+    }
+
+    log.debug("DB 저장 후 혹은 저장된 User 정보: {}", savedUser);
+    return savedUser;
+  }
+
+  public UserDTO createUserDTO(String nickName, String email) {
+    return UserDTO.of(nickName, email);
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/service/LoginService.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/service/LoginService.java
@@ -72,7 +72,7 @@ public class LoginService {
     return savedUser;
   }
 
-  public UserDTO createUserDTO(String nickName, String email) {
-    return UserDTO.of(nickName, email);
+  public UserDTO createUserDTO(User user) {
+    return UserDTO.of(user.getNickname(), user.getEmail());
   }
 }

--- a/BE/src/main/java/kr/codesquad/airbnb11/service/LoginService.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/service/LoginService.java
@@ -9,6 +9,7 @@ import kr.codesquad.airbnb11.domain.user.UserDTO;
 import kr.codesquad.airbnb11.domain.user.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,9 @@ public class LoginService {
   private final GithubKey githubKey;
   private final OAuthService authService;
   private final UserRepository userRepository;
+
+  @Value("${host}")
+  private String host;
 
   public LoginService(GithubKey githubKey, OAuthService authService,
       UserRepository userRepository) {
@@ -48,10 +52,9 @@ public class LoginService {
 
     headers.add("Authorization", "Bearer " + jwt);
     headers.add("Set-Cookie", "jwt=" + jwt + "; Path=/" + "; Max-Age=" + maxAge + ";");
-    headers.setLocation(URI.create("http://localhost:8080/login"));
+    headers.setLocation(URI.create("http://"+host+"/login"));
     return headers;
   }
-
 
   public User insertUser(String token) {
     User user = authService.getUserInfoToToken(token);
@@ -59,7 +62,8 @@ public class LoginService {
     User savedUser;
 
     try {
-      savedUser = userRepository.findByEmail(user.getEmail()).orElseThrow(UserNotFoundException::new);
+      savedUser = userRepository.findByEmail(user.getEmail())
+          .orElseThrow(UserNotFoundException::new);
     } catch (UserNotFoundException e) {
       savedUser = userRepository.save(user);
     }

--- a/BE/src/main/java/kr/codesquad/airbnb11/service/OAuthService.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/service/OAuthService.java
@@ -1,0 +1,93 @@
+package kr.codesquad.airbnb11.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import kr.codesquad.airbnb11.common.error.exception.UserNotFoundException;
+import kr.codesquad.airbnb11.common.security.GithubPayload;
+import kr.codesquad.airbnb11.common.security.GithubToken;
+import kr.codesquad.airbnb11.common.security.GithubUser;
+import kr.codesquad.airbnb11.domain.user.User;
+import kr.codesquad.airbnb11.domain.user.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class OAuthService {
+
+  private static final String GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+  private static final String GITHUB_USER_API_URL = "https://api.github.com/user";
+  private static final Logger log = LoggerFactory.getLogger(OAuthService.class);
+  private final ObjectMapper objectMapper;
+  private final RestTemplate restTemplate = new RestTemplate();
+  private final UserRepository userRepository;
+
+  public OAuthService(ObjectMapper objectMapper, UserRepository userRepository) {
+    this.objectMapper = objectMapper;
+    this.userRepository = userRepository;
+  }
+
+  public GithubToken getCodeFromGithubToken(String code) {
+    HttpEntity<GithubPayload> request = new HttpEntity<>(GithubPayload.valueOf(code));
+    return restTemplate.postForEntity(GITHUB_ACCESS_TOKEN_URL, request, GithubToken.class)
+        .getBody();
+  }
+
+  public User insertUser(String token) {
+    User user = getUserInfoToToken(token);
+    User saved;
+    log.debug("DB 저장 전 User 정보: {}", user);
+
+    try {
+      saved = userRepository.findByEmail(user.getEmail()).orElseThrow(UserNotFoundException::new);
+    } catch (UserNotFoundException e) {
+      saved = userRepository.save(user);
+    }
+    log.debug("DB 저장 후 혹은 저장된 User 정보: {}", saved);
+
+    return saved;
+  }
+
+  public User getUserInfoToToken(String token) {
+    HttpHeaders requestHeaders = new HttpHeaders();
+    requestHeaders.set("Authorization", "token " + token);
+
+    GithubUser user = Optional
+        .ofNullable(restTemplate
+            .exchange(GITHUB_USER_API_URL, HttpMethod.GET, new HttpEntity<>(requestHeaders),
+                GithubUser.class).getBody())
+        .orElseThrow(UserNotFoundException::new);
+    user.setToken(token);
+
+    // 공개된 user email이 없는 경우가 있어서 없는 경우 email API를 사용해서 채워줍니다.
+    if (user.getEmail() == null) {
+      user.setEmail(getEmailFromGitHub(requestHeaders));
+    }
+
+    return User.builder(user).build();
+  }
+
+  public String getEmailFromGitHub(HttpHeaders requestHeaders) {
+    String email = restTemplate
+        .exchange(GITHUB_USER_API_URL + "/emails", HttpMethod.GET, new HttpEntity<>(requestHeaders),
+            String.class).getBody();
+
+    try {
+      JsonNode emailNode = objectMapper.readTree(email);
+      for (JsonNode jsonNode : emailNode) {
+        if (jsonNode.get("primary").asBoolean()) {
+          return jsonNode.get("email").textValue();
+        }
+      }
+    } catch (JsonProcessingException e) {
+      log.error("Json 형식이 잘못 되었어요.", e);
+    }
+    return null;
+  }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb11/service/OAuthService.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/service/OAuthService.java
@@ -38,7 +38,7 @@ public class OAuthService {
 
   public GithubToken getTokenFromCode(String code) {
     HttpEntity<GithubPayload> request = new HttpEntity<>(
-        GithubPayload.of(githubKey.getClientId(), githubKey.getClientSecret(), code));
+        GithubPayload.of(githubKey, code));
     return restTemplate.postForEntity(GITHUB_ACCESS_TOKEN_URL, request, GithubToken.class)
         .getBody();
   }

--- a/BE/src/main/java/kr/codesquad/airbnb11/service/OAuthService.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/service/OAuthService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
 import kr.codesquad.airbnb11.common.error.exception.UserNotFoundException;
+import kr.codesquad.airbnb11.common.security.GithubKey;
 import kr.codesquad.airbnb11.common.security.GithubPayload;
 import kr.codesquad.airbnb11.common.security.GithubToken;
 import kr.codesquad.airbnb11.common.security.GithubUser;
@@ -24,17 +25,22 @@ public class OAuthService {
   private static final String GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
   private static final String GITHUB_USER_API_URL = "https://api.github.com/user";
   private static final Logger log = LoggerFactory.getLogger(OAuthService.class);
+
   private final ObjectMapper objectMapper;
   private final RestTemplate restTemplate = new RestTemplate();
   private final UserRepository userRepository;
+  private final GithubKey githubKey;
 
-  public OAuthService(ObjectMapper objectMapper, UserRepository userRepository) {
+  public OAuthService(ObjectMapper objectMapper,
+      UserRepository userRepository, GithubKey githubKey) {
     this.objectMapper = objectMapper;
     this.userRepository = userRepository;
+    this.githubKey = githubKey;
   }
 
-  public GithubToken getCodeFromGithubToken(String code) {
-    HttpEntity<GithubPayload> request = new HttpEntity<>(GithubPayload.valueOf(code));
+  public GithubToken getTokenFromCode(String code) {
+    HttpEntity<GithubPayload> request = new HttpEntity<>(
+        GithubPayload.of(githubKey.getClientId(), githubKey.getClientSecret(), code));
     return restTemplate.postForEntity(GITHUB_ACCESS_TOKEN_URL, request, GithubToken.class)
         .getBody();
   }

--- a/BE/src/main/java/kr/codesquad/airbnb11/service/OAuthService.java
+++ b/BE/src/main/java/kr/codesquad/airbnb11/service/OAuthService.java
@@ -10,7 +10,6 @@ import kr.codesquad.airbnb11.common.security.GithubPayload;
 import kr.codesquad.airbnb11.common.security.GithubToken;
 import kr.codesquad.airbnb11.common.security.GithubUser;
 import kr.codesquad.airbnb11.domain.user.User;
-import kr.codesquad.airbnb11.domain.user.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
@@ -27,14 +26,13 @@ public class OAuthService {
   private static final Logger log = LoggerFactory.getLogger(OAuthService.class);
 
   private final ObjectMapper objectMapper;
-  private final RestTemplate restTemplate = new RestTemplate();
-  private final UserRepository userRepository;
+  private final RestTemplate restTemplate;
   private final GithubKey githubKey;
 
   public OAuthService(ObjectMapper objectMapper,
-      UserRepository userRepository, GithubKey githubKey) {
+      RestTemplate restTemplate, GithubKey githubKey) {
     this.objectMapper = objectMapper;
-    this.userRepository = userRepository;
+    this.restTemplate = restTemplate;
     this.githubKey = githubKey;
   }
 
@@ -45,29 +43,14 @@ public class OAuthService {
         .getBody();
   }
 
-  public User insertUser(String token) {
-    User user = getUserInfoToToken(token);
-    User saved;
-    log.debug("DB 저장 전 User 정보: {}", user);
-
-    try {
-      saved = userRepository.findByEmail(user.getEmail()).orElseThrow(UserNotFoundException::new);
-    } catch (UserNotFoundException e) {
-      saved = userRepository.save(user);
-    }
-    log.debug("DB 저장 후 혹은 저장된 User 정보: {}", saved);
-
-    return saved;
-  }
-
   public User getUserInfoToToken(String token) {
     HttpHeaders requestHeaders = new HttpHeaders();
     requestHeaders.set("Authorization", "token " + token);
 
-    GithubUser user = Optional
-        .ofNullable(restTemplate
-            .exchange(GITHUB_USER_API_URL, HttpMethod.GET, new HttpEntity<>(requestHeaders),
-                GithubUser.class).getBody())
+    GithubUser user = Optional.ofNullable(restTemplate
+        .exchange(GITHUB_USER_API_URL, HttpMethod.GET, new HttpEntity<>(requestHeaders),
+            GithubUser.class)
+        .getBody())
         .orElseThrow(UserNotFoundException::new);
     user.setToken(token);
 
@@ -75,7 +58,6 @@ public class OAuthService {
     if (user.getEmail() == null) {
       user.setEmail(getEmailFromGitHub(requestHeaders));
     }
-
     return User.builder(user).build();
   }
 

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -50,8 +50,8 @@ logging:
 
 host: 13.124.223.191/api
 github:
-  client-id: 9875df2fa499cdb9ff25
-  client-secret: d1dff8a224738636f3fb0e6a3781b5ee8c17f494
+  client-id: ee75619e5811bb328936
+  client-secret: a13148ae7b76f7ce892d6d315da636b9b19a2faf
 
 ---
 spring:
@@ -70,6 +70,6 @@ logging:
 
 host: 3.232.101.173/api
 github:
-  client-id: 9875df2fa499cdb9ff25
-  client-secret: d1dff8a224738636f3fb0e6a3781b5ee8c17f494
+  client-id: 079d5502cd95167fd24b
+  client-secret: d79455358c12197814137009b0ad5c7fb733ee2a
 

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -29,6 +29,9 @@ logging:
     kr.codesquad.airbnb11: debug
 
 host: localhost:8080
+github:
+  client-id: 9875df2fa499cdb9ff25
+  client-secret: d1dff8a224738636f3fb0e6a3781b5ee8c17f494
 
 ---
 spring:
@@ -46,6 +49,9 @@ logging:
     kr.codesquad.airbnb11: debug
 
 host: 13.124.223.191/api
+github:
+  client-id: 9875df2fa499cdb9ff25
+  client-secret: d1dff8a224738636f3fb0e6a3781b5ee8c17f494
 
 ---
 spring:
@@ -63,3 +69,7 @@ logging:
     kr.codesquad.airbnb11: debug
 
 host: 3.232.101.173/api
+github:
+  client-id: 9875df2fa499cdb9ff25
+  client-secret: d1dff8a224738636f3fb0e6a3781b5ee8c17f494
+

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -45,7 +45,7 @@ logging:
     sql: debug
     kr.codesquad.airbnb11: debug
 
-host: localhost:80/api
+host: 13.124.223.191/api
 
 ---
 spring:
@@ -62,4 +62,4 @@ logging:
     sql: debug
     kr.codesquad.airbnb11: debug
 
-host: localhost:80/api
+host: 3.232.101.173/api

--- a/BE/src/test/java/kr/codesquad/airbnb11/domain/room/RoomRepositoryTest.java
+++ b/BE/src/test/java/kr/codesquad/airbnb11/domain/room/RoomRepositoryTest.java
@@ -3,6 +3,7 @@ package kr.codesquad.airbnb11.domain.room;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,17 +18,8 @@ class RoomRepositoryTest {
   @Autowired
   RoomRepository repository;
 
-  @Test
-  void 조건에_해당하는_방이_없을때() {
-    List<Room> responseList = repository.findAllByMaxPersonCountIsGreaterThanEqual(8);
-    assertThat(responseList.size()).isEqualTo(0);
-  }
-
-  @Test
-  void 최소인원_이상_방_검색하기() {
-
-    int minPersonCount = 8;
-
+  @BeforeEach
+  void 데이터_생성() {
     Room r1 = Room.builder()
         .title("room1")
         .maxPersonCount(8)
@@ -52,6 +44,20 @@ class RoomRepositoryTest {
     repository.save(r2);
     repository.save(r3);
     repository.save(r4);
+  }
+
+  @Test
+  void 조건에_해당하는_방이_없을때() {
+    List<Room> responseList = repository.findAllByMaxPersonCountIsGreaterThanEqual(11);
+    assertThat(responseList.size()).isEqualTo(0);
+  }
+
+  @Test
+  void 최소인원_이상_방_검색하기() {
+    List<Room> temp = repository.findAllByMaxPersonCountIsGreaterThanEqual(0);
+    assertThat(temp.size()).isEqualTo(4);
+
+    int minPersonCount = 8;
 
     List<Room> responseList = repository.findAllByMaxPersonCountIsGreaterThanEqual(minPersonCount);
     int size = responseList.size();

--- a/BE/src/test/resources/application.yml
+++ b/BE/src/test/resources/application.yml
@@ -14,3 +14,7 @@ logging:
     kr.codesquad.airbnb11: debug
 
 host: localhost:8080
+github:
+  client-id: 9875df2fa499cdb9ff25
+  client-secret: d1dff8a224738636f3fb0e6a3781b5ee8c17f494
+

--- a/BE/src/test/resources/application.yml
+++ b/BE/src/test/resources/application.yml
@@ -12,3 +12,5 @@ logging:
     web: debug
     sql: debug
     kr.codesquad.airbnb11: debug
+
+host: localhost:8080


### PR DESCRIPTION
- 진짜 기능만 구현된 상태입니다.
   - (해당 유저가 DB에 없을때) 깃헙 로그인 -> 인증 -> DB 저장 -> 저장된 user 정보를 기반으로 jwt 반환
   - (해당 유저가 DB에 있을때) 깃헙 로그인 -> 인증 -> DB에 있는 걸 확인하고 가져옴 -> 저장되어있는 user 정보를 기반으로 jwt 반환 
- 보여준 코드를 거의 그대로 재사용하였습니다. 감사합니다!!
- `LoginController` 부분은 추후 Login Service 생성을 통한 리팩토링이 필요해보입니다.
- yml 파일에서 각 개발환경별로 ,github id와 client id를 작성해야할듯 싶습니다.
- 유저 생성과 관련된 테스트는 아직 작성하지 않았습니다.